### PR TITLE
append 'conda activate default' to ~/.bashrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,11 @@ ENV MINICONDA_PATH="/opt/miniconda" CONDA_DEFAULT_ENV="default"
 RUN /opt/docker/install-miniconda.sh
 ENV PATH="$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 RUN conda create -n $CONDA_DEFAULT_ENV python=3.6
-RUN conda init bash
-RUN echo "conda activate $CONDA_DEFAULT_ENV" > ~/.bashrc
+# force this to run in bash since we're initializing for bash
+RUN /bin/bash -c "set -e; conda init bash"
+# append the conda activate command to the ~/.bashrc file because 
+# 'conda init bash' writes to ~/.bashrc
+RUN echo "conda activate $CONDA_DEFAULT_ENV" >> ~/.bashrc
 RUN hash -r
 
 # install specific tools
@@ -25,6 +28,8 @@ RUN conda install -y --quiet --file /opt/docker/requirements-conda.txt
 
 # install scripts
 COPY scripts/* /opt/docker/scripts/
+
+RUN /bin/bash -c "set -e; echo -n 'esearch version: '; esearch -version"
 
 # set up entrypoint
 CMD ["/bin/bash"]


### PR DESCRIPTION
append `conda activate default` to `~/.bashrc` rather than overwriting it since `conda init bash` also writes to the file. Also, ensure `conda init bash` runs in a `bash` session. Print the `esearch` version as part of the build process.