### PR TITLE
build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,17 +15,12 @@ ENV MINICONDA_PATH="/opt/miniconda" CONDA_DEFAULT_ENV="default"
 RUN /opt/docker/install-miniconda.sh
 ENV PATH="$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 RUN conda create -n $CONDA_DEFAULT_ENV python=3.6
-# force this to run in bash since we're initializing for bash
-RUN /bin/bash -c "set -e; conda init bash"
-RUN /bin/bash -c "conda activate $CONDA_DEFAULT_ENV"
-# append the conda activate command to the ~/.bashrc file because 
-# 'conda init bash' writes to ~/.bashrc
-RUN echo "conda activate $CONDA_DEFAULT_ENV" >> ~/.bashrc
+RUN echo "source activate $CONDA_DEFAULT_ENV" >> ~/.bashrc
 RUN hash -r
 
 # install specific tools
 COPY requirements-conda.txt /opt/docker
-RUN conda install -y --quiet --file /opt/docker/requirements-conda.txt
+RUN "set -e; sync; conda install -y --quiet --file /opt/docker/requirements-conda.txt ; conda clean -y --all"
 
 # install scripts
 COPY scripts/* /opt/docker/scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"
 # install miniconda3 with our default channels and no other packages
 ENV MINICONDA_PATH="/opt/miniconda" CONDA_DEFAULT_ENV="default"
 RUN /opt/docker/install-miniconda.sh
-ENV PATH="$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-RUN /bin/bash -c "conda create -n $CONDA_DEFAULT_ENV python=3.6"
+ENV PATH="$MINICONDA_PATH/envs/$CONDA_DEFAULT_ENV/bin:$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+RUN conda create -n $CONDA_DEFAULT_ENV python=3.6
 RUN echo "source activate $CONDA_DEFAULT_ENV" >> ~/.bashrc
 RUN hash -r
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,13 @@ ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"
 ENV MINICONDA_PATH="/opt/miniconda" CONDA_DEFAULT_ENV="default"
 RUN /opt/docker/install-miniconda.sh
 ENV PATH="$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-RUN conda create -n $CONDA_DEFAULT_ENV python=3.6
+RUN /bin/bash -c "conda create -n $CONDA_DEFAULT_ENV python=3.6"
 RUN echo "source activate $CONDA_DEFAULT_ENV" >> ~/.bashrc
 RUN hash -r
 
 # install specific tools
 COPY requirements-conda.txt /opt/docker
-RUN "set -e; sync; conda install -y --quiet --file /opt/docker/requirements-conda.txt ; conda clean -y --all"
+RUN /bin/bash -c "set -e; sync; conda install -y --quiet --file /opt/docker/requirements-conda.txt ; conda clean -y --all"
 
 # install scripts
 COPY scripts/* /opt/docker/scripts/

--- a/WDL/task-sra_to_ubam.wdl
+++ b/WDL/task-sra_to_ubam.wdl
@@ -4,7 +4,7 @@ task Fetch_SRA_to_BAM {
 
     input {
         String  SRA_ID
-        String  docker = "quay.io/dpark01/ncbi-tools"
+        String  docker = "quay.io/broadinstitute/ncbi-tools"
     }
 
     command {


### PR DESCRIPTION
1. revert from conda init + activate to source activate
2. fix docker build by adding conda default env to dockerfile PATH manually (this is how we do it in viral-ngs)
3. switch WDL docker image from quay.io/dpark01/ncbi-tools to quay.io/broadinstitute/ncbi-tools