### PR TITLE
more reliable parsing of date from SRA metadata records

### DIFF
--- a/scripts/sra_to_ubam.sh
+++ b/scripts/sra_to_ubam.sh
@@ -19,7 +19,7 @@ PLATFORM=`cat ${SRA_ID}.json | jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE
 MODEL=`cat ${SRA_ID}.json | jq -r ".EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.PLATFORM.${PLATFORM}.INSTRUMENT_MODEL"`
 SAMPLE=`cat ${SRA_ID}.json | jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.SAMPLE.IDENTIFIERS.EXTERNAL_ID|select(.namespace == "BioSample")|.content'`
 LIBRARY=`cat ${SRA_ID}.json | jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.DESIGN.LIBRARY_DESCRIPTOR.LIBRARY_NAME'`
-RUNDATE=`cat ${SRA_ID}.json | jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.RUN_SET.RUN.SRAFiles|if (.SRAFile|type) == "object" then .SRAFile.date else .SRAFile[]|select(.supertype == "Original")|.date end' | cut -f 1 -d ' '`
+RUNDATE=`cat ${SRA_ID}.json | jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.RUN_SET.RUN.SRAFiles|if (.SRAFile|type) == "object" then .SRAFile.date else [.SRAFile[]|select(.supertype == "Original")][0].date end' | cut -f 1 -d ' '`
 
 sam-dump --unaligned --header ${SRA_ID} \
     | samtools view -bhS - \

--- a/scripts/sra_to_ubam.sh
+++ b/scripts/sra_to_ubam.sh
@@ -19,7 +19,7 @@ PLATFORM=`cat ${SRA_ID}.json | jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE
 MODEL=`cat ${SRA_ID}.json | jq -r ".EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.PLATFORM.${PLATFORM}.INSTRUMENT_MODEL"`
 SAMPLE=`cat ${SRA_ID}.json | jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.SAMPLE.IDENTIFIERS.EXTERNAL_ID|select(.namespace == "BioSample")|.content'`
 LIBRARY=`cat ${SRA_ID}.json | jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.EXPERIMENT.DESIGN.LIBRARY_DESCRIPTOR.LIBRARY_NAME'`
-RUNDATE=`cat ${SRA_ID}.json | jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.RUN_SET.RUN.SRAFiles.SRAFile[]|select(.supertype == "Original")|.date' | cut -f 1 -d ' '`
+RUNDATE=`cat ${SRA_ID}.json | jq -r '.EXPERIMENT_PACKAGE_SET.EXPERIMENT_PACKAGE.RUN_SET.RUN.SRAFiles|if (.SRAFile|type) == "object" then .SRAFile.date else .SRAFile[]|select(.supertype == "Original")|.date end' | cut -f 1 -d ' '`
 
 sam-dump --unaligned --header ${SRA_ID} \
     | samtools view -bhS - \


### PR DESCRIPTION
if SRAFile is an object, use its date. if it's not then it's probably an array of objects, and we can try to get the one marked "Original"