### PR TITLE
install mamba, install requirements list via mamba

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,14 @@ ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"
 ENV MINICONDA_PATH="/opt/miniconda" CONDA_DEFAULT_ENV="default"
 RUN /opt/docker/install-miniconda.sh
 ENV PATH="$MINICONDA_PATH/envs/$CONDA_DEFAULT_ENV/bin:$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+RUN conda install mamba
 RUN conda create -n $CONDA_DEFAULT_ENV python=3.7
 RUN echo "source activate $CONDA_DEFAULT_ENV" >> ~/.bashrc
 RUN hash -r
 
 # install specific tools
 COPY requirements-conda.txt /opt/docker
-RUN /bin/bash -c "set -e; sync; conda install -y --quiet --file /opt/docker/requirements-conda.txt ; conda clean -y --all"
+RUN /bin/bash -c "set -e; sync; mamba install -y --quiet --file /opt/docker/requirements-conda.txt ; conda clean -y --all"
 
 # install tsv converter
 ENV ASYMMETRIK_REPO_COMMIT=af2d184da9da9fcc94c6a4d809210868bb8f3034

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV MINICONDA_PATH="/opt/miniconda" CONDA_DEFAULT_ENV="default"
 RUN /opt/docker/install-miniconda.sh
 ENV PATH="$MINICONDA_PATH/envs/$CONDA_DEFAULT_ENV/bin:$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 RUN conda install mamba
-RUN conda create -n $CONDA_DEFAULT_ENV python=3.7
+RUN conda create -n $CONDA_DEFAULT_ENV python=3.8
 RUN echo "source activate $CONDA_DEFAULT_ENV" >> ~/.bashrc
 RUN hash -r
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,17 +15,17 @@ RUN /opt/docker/install-apt_packages.sh
 ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"
 
 # install miniconda3 with our default channels and no other packages
-ENV MINICONDA_PATH="/opt/miniconda" CONDA_DEFAULT_ENV="default"
+ENV MINICONDA_PATH="/opt/miniconda" CONDA_ENV_NAME="custom-env"
 RUN /opt/docker/install-miniconda.sh
-ENV PATH="$MINICONDA_PATH/envs/$CONDA_DEFAULT_ENV/bin:$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-RUN conda create -n $CONDA_DEFAULT_ENV python=3.8
+ENV PATH="$MINICONDA_PATH/envs/$CONDA_ENV_NAME/bin:$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+RUN conda create -n $CONDA_ENV_NAME python=3.8
+RUN echo "conda activate $CONDA_ENV_NAME" >> ~/.bashrc
 RUN conda install mamba
-RUN echo "source activate $CONDA_DEFAULT_ENV" >> ~/.bashrc
 RUN hash -r
 
 # install specific tools
 COPY requirements-conda.txt /opt/docker
-RUN /bin/bash -c "set -e; sync; mamba install -y --quiet --file /opt/docker/requirements-conda.txt ; conda clean -y --all"
+RUN /bin/bash -c "set -e; sync; mamba install -n ${CONDA_ENV_NAME} -y --quiet --file /opt/docker/requirements-conda.txt ; conda clean -y --all"
 
 # install tsv converter
 ENV ASYMMETRIK_REPO_COMMIT=af2d184da9da9fcc94c6a4d809210868bb8f3034

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"
 ENV MINICONDA_PATH="/opt/miniconda" CONDA_DEFAULT_ENV="default"
 RUN /opt/docker/install-miniconda.sh
 ENV PATH="$MINICONDA_PATH/envs/$CONDA_DEFAULT_ENV/bin:$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-RUN conda install mamba
 RUN conda create -n $CONDA_DEFAULT_ENV python=3.8
+RUN conda install mamba
 RUN echo "source activate $CONDA_DEFAULT_ENV" >> ~/.bashrc
 RUN hash -r
 

--- a/install-miniconda.sh
+++ b/install-miniconda.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e -o pipefail
 
-MINICONDA_VERSION="4.6.14"
-MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
+MINICONDA_VERSION="23.3.1"
+MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-0-Linux-x86_64.sh"
 
 # download and run miniconda installer script
 curl -sSL $MINICONDA_URL > "/tmp/Miniconda3-${MINICONDA_VERSION}-x86_64.sh"

--- a/install-miniconda.sh
+++ b/install-miniconda.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -o pipefail
+set -x -e -o pipefail
 
 MINICONDA_VERSION="23.3.1"
 MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-0-Linux-x86_64.sh"
@@ -18,4 +18,9 @@ conda config --add channels defaults
 conda config --add channels bioconda
 conda config --add channels conda-forge
 conda config --set auto_update_conda false
+
 conda clean -y --all
+
+echo "$MINICONDA_PATH"
+ls -lah $MINICONDA_PATH
+

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -1,5 +1,5 @@
-entrez-direct=13.9
-sra-tools=2.10.9
-samtools=1.12
-picard-slim=2.21.1
-biopython=1.70
+entrez-direct=16.2
+sra-tools=2.11.0
+samtools=1.17
+picard-slim=2.27.4
+biopython=1.81


### PR DESCRIPTION
install mamba for faster dependency resolution
install requirements list via mamba
bump python to 3.8 to reflect [current lowest version used by bioconda](https://github.com/bioconda/bioconda-utils/blob/master/bioconda_utils/bioconda_utils-conda_build_config.yaml)