### PR TITLE
Fix: use Docker v2 manifests for Cromwell/Terra call caching

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -110,9 +110,11 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.all-tags.outputs.tags }}
           labels: ${{ steps.meta-ghcr.outputs.labels }}
+          provenance: false
+          sbom: false
+          outputs: type=image,push=${{ github.event_name != 'pull_request' }},oci-mediatypes=false
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
- Configure docker/build-push-action@v6 to produce Docker v2 manifests instead of OCI, matching the approach used in py3-bio
- Adds provenance: false, sbom: false, and oci-mediatypes=false to prevent OCI image indexes that break Cromwell/Terra call caching
- Replaces push: with equivalent setting inside outputs: (cannot use both together)

## Context
docker/build-push-action@v4+ defaults to enabling provenance attestations, which forces OCI manifest format. Cromwell/Terra call caching requires deterministic image hashing via Docker v2 manifest lists -- OCI manifests produce different hashes and break cache hits.

This was previously discovered and fixed in viral-ngs/py3-bio.

## Test plan
- [ ] Verify CI build succeeds on this branch
- [ ] After merge, inspect pushed image format with: docker buildx imagetools inspect ghcr.io/broadinstitute/ncbi-tools:latest -- should show application/vnd.docker.distribution.manifest.v2+json (not vnd.oci.image)
- [ ] Verify Cromwell/Terra call caching works with the rebuilt image