### PR TITLE
harden GHA workflow + drop build-only apt packages

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches: [main, master]
   schedule:
-    - cron: '0 6 * * 1'  # Weekly Monday scan for new CVEs
+    - cron: '0 12 * * *'  # Daily scan for new CVEs
   workflow_dispatch:
 
 env:
@@ -37,17 +37,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Login to custom registry
         if: github.event_name != 'pull_request' && env.HAS_CUSTOM_REGISTRY == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.CUSTOM_REGISTRY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for GHCR
         id: meta-ghcr
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE_NAME }}
           tags: |
@@ -75,7 +75,7 @@ jobs:
       - name: Extract metadata (tags, labels) for custom registry
         id: meta-custom
         if: env.HAS_CUSTOM_REGISTRY == 'true'
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.CUSTOM_REGISTRY }}/${{ env.CUSTOM_IMAGE_NAME }}
           tags: |
@@ -106,7 +106,7 @@ jobs:
           echo "tag=$FIRST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -128,11 +128,11 @@ jobs:
       packages: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -165,7 +165,10 @@ jobs:
   # Scan the pushed image for vulnerabilities
   scan:
     needs: build
-    if: always() && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    if: |
+      always() &&
+      (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -173,7 +176,7 @@ jobs:
       security-events: write
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -193,10 +196,11 @@ jobs:
         run: docker pull ${{ steps.image-ref.outputs.ref }}
 
       - name: Checkout (for ignore policy)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner (table)
-        uses: aquasecurity/trivy-action@master
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           image-ref: ${{ steps.image-ref.outputs.ref }}
           format: table
@@ -207,7 +211,8 @@ jobs:
           trivyignores: .trivyignore
 
       - name: Run Trivy vulnerability scanner (SARIF)
-        uses: aquasecurity/trivy-action@master
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         if: always()
         with:
           image-ref: ${{ steps.image-ref.outputs.ref }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,10 @@ ENV ASYMMETRIK_REPO_COMMIT=af2d184da9da9fcc94c6a4d809210868bb8f3034
 COPY --chown=$MAMBA_USER:$MAMBA_USER install-tsv_converter.sh /opt/docker/install-tsv_converter.sh
 USER root
 RUN /opt/docker/install-tsv_converter.sh && \
-    chown -R $MAMBA_USER:$MAMBA_USER /opt/converter
+    chown -R $MAMBA_USER:$MAMBA_USER /opt/converter && \
+    apt-get purge -y --auto-remove build-essential python3-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 USER $MAMBA_USER
 
 # Install scripts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ncbi-tools
 
 [![Build and Push Docker Image](https://github.com/broadinstitute/ncbi-tools/actions/workflows/docker.yml/badge.svg)](https://github.com/broadinstitute/ncbi-tools/actions/workflows/docker.yml)
+[![Quay.io](https://img.shields.io/badge/quay.io-ncbi--tools-blue)](https://quay.io/repository/broadinstitute/ncbi-tools?tab=tags&tag=latest)
 
 Docker image packaging NCBI bioinformatics tools for retrieving sequence data, metadata, and converting between formats. Designed for use as a runtime container in WDL/Cromwell genomics pipelines on platforms like Terra.
 


### PR DESCRIPTION
## Summary

Hygiene pass on the GHA workflow + a small Dockerfile fix to drop one open HIGH CVE. Mirrors lessons learned in broadinstitute/py3-bio#12 and broadinstitute/read-qc-tools#2.

### Workflow changes (`.github/workflows/docker.yml`)

- **Action version bumps to Node.js 24 majors** ahead of the [Node.js 20 deprecation on GHA runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (forced migration 2026-06-02):

  | Action | Before | After |
  |---|---|---|
  | `actions/checkout` | `v4` | `v6` |
  | `docker/setup-qemu-action` | `v3` | `v4` |
  | `docker/setup-buildx-action` | `v3` | `v4` |
  | `docker/login-action` | `v3` | `v4` |
  | `docker/metadata-action` | `v5` | `v6` |
  | `docker/build-push-action` | `v6` | `v7` |
  | `aquasecurity/trivy-action` | `@master` | SHA `ed142fd…` (v0.36.0) |
  | `github/codeql-action/upload-sarif` | `v4` | `v4` (already Node.js 24) |

- **SHA-pin `aquasecurity/trivy-action`** following the [March 2026 trivy-action supply-chain incident](https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know/) where all version tags were force-pushed to malicious commits.
- **Daily noon UTC scan** (was weekly Mondays at 06:00 UTC) so new CVEs surface within ~24h.
- **Guard scan job on `needs.build.result == 'success' || 'skipped'`** so a failed build doesn't trigger a doomed scan.

### Dockerfile

Purge `build-essential` and `python3-dev` (and transitive `linux-libc-dev`) after the converter `npm install`. This closes [CVE-2026-23112](https://avd.aquasec.com/nvd/cve-2026-23112) (#8 in the security tab). Build deps are only needed at converter-install time for native modules like `libxmljs`; runtime Python comes from conda.

### README

Add a Quay.io badge alongside the existing GHA build badge.

### Open CVEs still outstanding

The other six HIGH-severity Security-tab findings all derive from the pinned 2018-era Asymmetrik TSV converter and its stale `node_modules/` tree. Tracked in #20 with two remediation options. Trivy stays non-blocking (`exit-code: '0'`) until that work lands, per `3bf3eda`.

## Test plan

- [ ] PR `build` and `test` jobs pass on the new action versions.
- [ ] PR `scan` job runs (push event after merge) on the SHA-pinned Trivy and produces SARIF.
- [ ] After merge, CVE-2026-23112 (`linux-libc-dev`) drops off the Security tab on the next scan.
- [ ] At the next 12:00 UTC tick after merge, the scheduled scan fires (build skipped → exercises the new `needs.build.result == 'skipped'` clause).
- [ ] README renders both badges; Quay badge links to the correct tags page.
