### PR TITLE
fix: modernize TSV converter deps + add XSD validation (closes #20)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -205,7 +205,7 @@ jobs:
           image-ref: ${{ steps.image-ref.outputs.ref }}
           format: table
           severity: CRITICAL,HIGH
-          exit-code: '0'
+          exit-code: '1'
           ignore-unfixed: true
           ignore-policy: .trivy-ignore-policy.rego
           trivyignores: .trivyignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     apt-get install -y -qq --no-install-recommends \
         ca-certificates git wget curl locales \
         build-essential python3-dev && \
+    apt-get install -y --only-upgrade -qq gpgv && \
     locale-gen en_US.UTF-8 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/env.yaml
+++ b/env.yaml
@@ -16,3 +16,4 @@ dependencies:
   - pigz
   - zstd
   - pytest
+  - lxml>=5

--- a/install-tsv_converter.sh
+++ b/install-tsv_converter.sh
@@ -8,6 +8,28 @@ tar -xf "$ASYMMETRIK_REPO_COMMIT.tar.gz" -C /opt/converter --strip-components=1
 
 cd /opt/converter
 mkdir -p logs staging
+
+# Inject npm overrides to pull CVE-free transitive deps (issue #20).
+# The upstream package.json (commit pinned in the Dockerfile) is from 2018 and
+# pulls vulnerable versions of tar, glob, serialize-javascript, and ssh2.
+jq '. + {overrides: {
+  "tar": ">=7.5.7",
+  "glob": ">=10.5.0",
+  "serialize-javascript": ">=7.0.3",
+  "ssh2": ">=1.4.0",
+  "minimatch": ">=3.1.4"
+}}' package.json > package.json.new && mv package.json.new package.json
+
 npm install
 rm -rf files/sample.tsv reports/sample-report.xml files/tests reports/tests
 cd -
+
+# Remove the npm CLI now that the converter is installed (issue #20).
+# npm itself bundles vulnerable copies of tar/glob/minimatch/etc. The converter
+# runtime only needs `node`, not `npm`/`npx`/`corepack`. Deleting these here
+# (in the same RUN layer as the install) keeps them out of the final image.
+rm -rf /opt/conda/lib/node_modules/npm \
+       /opt/conda/lib/node_modules/corepack \
+       /opt/conda/bin/npm \
+       /opt/conda/bin/npx \
+       /opt/conda/bin/corepack

--- a/tests/data/xsds/BioSample.xsd
+++ b/tests/data/xsds/BioSample.xsd
@@ -2,7 +2,7 @@
 <!-- $Id$ -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SP.common" version="2.0">
-  <xs:import schemaLocation="./xsds/Common.xsd" namespace="SP.common"/>
+  <xs:import schemaLocation="./Common.xsd" namespace="SP.common"/>
 
   <!-- BioSample object -->
   <xs:element name="BioSample" type="typeBioSample"/>

--- a/tests/data/xsds/Submission.xsd
+++ b/tests/data/xsds/Submission.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:com="SP.common" version="2.0">
-  <xs:import schemaLocation="./xsds/Common.xsd" namespace="SP.common"/>
+  <xs:import schemaLocation="./Common.xsd" namespace="SP.common"/>
 
   <!-- Main Submission XML -->
   <xs:element name="Submission">

--- a/tests/test_converter_golden.py
+++ b/tests/test_converter_golden.py
@@ -24,9 +24,30 @@ from pathlib import Path
 from xml.etree import ElementTree as ET
 
 import pytest
+from lxml import etree as LET
 
 CONVERTER_DIR = "/opt/converter"
 TEST_DATA_DIR = Path(__file__).parent / "data"
+SUBMISSION_XSD = TEST_DATA_DIR / "xsds" / "Submission.xsd"
+
+# Cache compiled schema across tests
+_SUBMISSION_SCHEMA: LET.XMLSchema | None = None
+
+
+def _get_submission_schema() -> LET.XMLSchema:
+    global _SUBMISSION_SCHEMA
+    if _SUBMISSION_SCHEMA is None:
+        _SUBMISSION_SCHEMA = LET.XMLSchema(LET.parse(str(SUBMISSION_XSD)))
+    return _SUBMISSION_SCHEMA
+
+
+def _validate_submission_xsd(xml_path: Path) -> None:
+    """Validate a converter output file against the NCBI Submission XSD."""
+    schema = _get_submission_schema()
+    doc = LET.parse(str(xml_path))
+    if not schema.validate(doc):
+        errors = "\n".join(str(e) for e in schema.error_log)
+        pytest.fail(f"XSD validation failed for {xml_path}:\n{errors}")
 MINIMAL_CONFIG = {
     "ftpConfig": {
         "host": "fakehost",
@@ -120,6 +141,8 @@ def run_converter(tsv_filename: str, config: dict, extra_args: list[str] | None 
             f"Output XML not found. Files in converter/files/: "
             f"{list(Path(CONVERTER_DIR, 'files').rglob('*.xml'))}"
         )
+
+    _validate_submission_xsd(output_xml)
 
     tree = ET.parse(output_xml)
     return tree.getroot()


### PR DESCRIPTION
## Summary

Closes #20.

Modernizes the Asymmetrik TSV converter's transitive deps (Option B from the issue) without touching the upstream pin, plus a couple of related hardening steps that surfaced during local verification:

- **Test hardening (precursor):** wire the previously-vendored NCBI XML schemas into the existing converter test suite as XSD validation. Catches structural regressions a transitive-dep bump might cause that the per-field assertions could miss.
- **Converter deps:** inject an npm `overrides` block into `package.json` before `npm install`, pulling CVE-free versions of `tar`, `glob`, `serialize-javascript`, `ssh2`, and `minimatch`. Closes 5 of the 6 issue-listed converter CVEs at the source.
- **npm CLI removal:** delete `/opt/conda/lib/node_modules/npm` (plus `npx`, `corepack`, and bin scripts) after install. The conda `nodejs` package vendors `npm 10.8.2`, which itself bundles old copies of tar/glob/minimatch — Trivy was reporting those even after the converter overrides took effect. The runtime only invokes `node src/main.js`, so npm is build-time only.
- **gpgv patch:** surgical `apt-get install --only-upgrade gpgv` for CVE-2025-68973 (Ubuntu 24.04 base, unrelated to #20 but blocked the Trivy re-block). Mirrors the surgical convention from b08b5d4.
- **Trivy re-block:** flip `exit-code: '0'` → `'1'` on the workflow's HIGH/CRITICAL gate.

## Why not bump conda nodejs?

The conda `nodejs` package's bundled `npm` would be modern enough at Node 22 (npm 10.9.x has patched bundled deps), but `libxmljs ^0.19.7` (a converter dep, 2018-vintage NAN bindings) fails to compile against V8 in Node 20+. Removing npm post-install sidesteps that with no runtime risk and no need to override `libxmljs` itself.

## Trade-off worth flagging

Deleting npm leaves conda's package metadata inconsistent with the filesystem. Harmless for an immutable image — we never re-run `micromamba install` at container runtime — but it would break a `micromamba install` invoked inside a running container.

## Test plan

- [x] `docker build .` succeeds (Node 18, libxmljs builds, converter installs)
- [x] `docker run ... python -m pytest tests/ -v` — all 18 tests pass (13 conversion tests now also XSD-validate against `tests/data/xsds/Submission.xsd`)
- [x] Local `trivy image --severity HIGH,CRITICAL --ignore-unfixed` is clean (0 findings)
- [x] Verified all 6 issue CVEs are gone:
  - CVE-2026-24842, CVE-2026-23950 (node-tar) — installed `tar@7.5.15`
  - CVE-2025-64756 (glob) — installed `glob@13.0.6`
  - GHSA-5c6j-r48x-rmvq (serialize-javascript) — installed `serialize-javascript@7.0.5`
  - CVE-2020-26301 (ssh2) — installed `ssh2@1.17.0`
- [ ] CI: build + test + scan all green with blocking Trivy
- [ ] After next scheduled scan: GitHub Security tab shows 0 of the 6 issue CVEs

## Acceptance (per issue #20)

- [x] All 6 HIGH CVEs no longer appear locally; verify on Security tab after merge
- [x] `tests/` (now including XSD validation) still passes
- [x] Trivy `exit-code` flipped from `'0'` back to `'1'`
- [ ] CI green with blocking Trivy
