### PR TITLE
fix: patch OpenSSL CVE-2026-45447

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install -y -qq --no-install-recommends \
         ca-certificates git wget curl locales \
         build-essential python3-dev && \
-    apt-get install -y --only-upgrade -qq gpgv && \
+    apt-get install -y --only-upgrade -qq gpgv openssl libssl3t64 && \
     locale-gen en_US.UTF-8 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

Patches CVE-2026-45447 (HIGH — use-after-free in `PKCS7_verify()`) by upgrading `openssl` and `libssl3t64` from `3.0.13-0ubuntu3.9` to `3.0.13-0ubuntu3.11`.

Resolves the daily Trivy scan failure from run [27279589143](https://github.com/broadinstitute/ncbi-tools/actions/runs/27279589143).

## Changes

- Extends the existing targeted `apt-get install --only-upgrade` call in `Dockerfile:11` to include `openssl` and `libssl3t64`
- Follows the same pattern as the `gpgv` upgrade on that line
- Inspired by [broadinstitute/viral-ngs#1090](https://github.com/broadinstitute/viral-ngs/pull/1090)

## Verification

Built locally and confirmed both packages upgraded to `3.0.13-0ubuntu3.11`:
```
$ docker run --rm ncbi-tools dpkg -l openssl libssl3t64
ii  libssl3t64:arm64 3.0.13-0ubuntu3.11 arm64        Secure Sockets Layer toolkit - shared libraries
ii  openssl          3.0.13-0ubuntu3.11 arm64        Secure Sockets Layer toolkit - cryptographic utility
```

CI Trivy scan should pass with 0 HIGH/CRITICAL findings.